### PR TITLE
Optimize: hoist the set() function out into its own closure

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,24 +13,16 @@ function Symbol() {
   if (!(this instanceof Symbol)) return new Symbol();
 
   // create a unique key based on a long uid for this symbol
-  var __key__ = this.__key__ = "__symbol__" + uid(32);
+  var key = this.__key__ = "__symbol__" + uid(32);
 
   // define a property on Object.prototype, so that whenever a property 
   // with the key we just generated is set on any object, it's automatically
   // marked as non-enumerable. this is technically global, but shouldn't matter
   // since it's unique and non-enumerable
-  Object.defineProperty(Object.prototype, __key__, {
+  Object.defineProperty(Object.prototype, key, {
     enumerable: false,
     get: function() {},
-    set: function(value) {
-      // Store the received value and mark it as non-enumerable
-      Object.defineProperty(this, __key__, {
-        enumerable: false,
-        configurable: true,
-        writeable: true,
-        value: value
-      });
-    }
+    set: setter(key)
   });
 }
 
@@ -49,5 +41,23 @@ Symbol.prototype.toString = function() {
 Symbol.prototype.dispose = function() {
   delete Object.prototype[this.__key__];
 };
+
+/**
+ * Returns a `set` function. This is so that *only* this closure will be
+ * retained in memory. Leaving the actual `Symbol` instance to be elidgible
+ * for garbage collection.
+ */
+
+function setter (key) {
+  return function(value) {
+    // Store the received value and mark it as non-enumerable
+    Object.defineProperty(this, key, {
+      enumerable: false,
+      configurable: true,
+      writeable: true,
+      value: value
+    });
+  };
+}
 
 module.exports = Symbol;


### PR DESCRIPTION
The intention here is to make the `Symbol` instance elidgible for garbage collection, and the `setter` closure be the only thing that gets retained in memory on the `Object.prototype`.
