### PR TITLE
fix typo in data descriptor

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function setter (key) {
     Object.defineProperty(this, key, {
       enumerable: false,
       configurable: true,
-      writeable: true,
+      writable: true,
       value: value
     });
   };


### PR DESCRIPTION
should be `'writable'` key
=> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Description
